### PR TITLE
Added missing "textdomain" statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ sap-installation-wizard-*.tar.bz2
 y2signal.log
 coverage/
 fisx-me
+sap-installation-wizard.pot

--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 18 14:42:07 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added missing "textdomain" statements (bsc#1194801)
+- 4.4.0
+
+-------------------------------------------------------------------
 Thu Feb  4 10:40:28 UTC 2021 - Peter Varkoly <varkoly@suse.com>
 
 - Adapt API change in IssuesPresenter

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -20,7 +20,7 @@ Name:           sap-installation-wizard
 Summary:        Installation wizard for SAP applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.3.7
+Version:        4.4.0
 Release:        0
 PreReq:         /bin/mkdir %insserv_prereq %fillup_prereq yast2
 BuildRequires:  yast2

--- a/src/lib/y2sap/media/complex.rb
+++ b/src/lib/y2sap/media/complex.rb
@@ -19,6 +19,10 @@
 # To contact Novell about this file by physical or electronic mail, you may
 # find current contact information at www.novell.com.
 
+=begin
+textdomain "sap-installation-wizard"
+=end
+
 module Y2Sap
   module MediaComplex
     include Yast

--- a/src/lib/y2sap/media/dialog.rb
+++ b/src/lib/y2sap/media/dialog.rb
@@ -22,6 +22,10 @@ require "yast"
 require "autoinstall/clients/ayast_setup"
 Yast.import "UI"
 
+=begin
+textdomain "sap-installation-wizard"
+=end
+
 module Y2Sap
   module MediaDialog
     include Yast

--- a/src/lib/y2sap/partitioning/product_partitioning.rb
+++ b/src/lib/y2sap/partitioning/product_partitioning.rb
@@ -19,6 +19,10 @@
 # To contact Novell about this file by physical or electronic mail, you may
 # find current contact information at www.novell.com.
 
+=begin
+textdomain "sap-installation-wizard"
+=end
+
 require "yast"
 require "open3"
 Yast.import "UI"

--- a/src/lib/y2sap/products/do_install.rb
+++ b/src/lib/y2sap/products/do_install.rb
@@ -24,6 +24,10 @@ require "open3"
 require "y2sap/partitioning/product_partitioning"
 Yast.import "UI"
 
+=begin
+textdomain "sap-installation-wizard"
+=end
+
 module Y2Sap
 
   # Install the selected products.

--- a/src/lib/y2sap/products/nw_installation_mode.rb
+++ b/src/lib/y2sap/products/nw_installation_mode.rb
@@ -19,6 +19,10 @@
 # To contact Novell about this file by physical or electronic mail, you may
 # find current contact information at www.novell.com.
 
+=begin
+textdomain "sap-installation-wizard"
+=end
+
 require "yast"
 Yast.import "UI"
 

--- a/src/lib/y2sap/products/nw_products.rb
+++ b/src/lib/y2sap/products/nw_products.rb
@@ -19,6 +19,10 @@
 # To contact Novell about this file by physical or electronic mail, you may
 # find current contact information at www.novell.com.
 
+=begin
+textdomain "sap-installation-wizard"
+=end
+
 require "yast"
 Yast.import "UI"
 

--- a/src/lib/y2sap/products/read_parameter.rb
+++ b/src/lib/y2sap/products/read_parameter.rb
@@ -19,6 +19,10 @@
 # To contact Novell about this file by physical or electronic mail, you may
 # find current contact information at www.novell.com.
 
+=begin
+textdomain "sap-installation-wizard"
+=end
+
 require "yast"
 require "autoinstall/clients/ayast_setup"
 

--- a/src/lib/y2sap/products/variables.rb
+++ b/src/lib/y2sap/products/variables.rb
@@ -19,6 +19,10 @@
 # To contact Novell about this file by physical or electronic mail, you may
 # find current contact information at www.novell.com.
 
+=begin
+textdomain "sap-installation-wizard"
+=end
+
 module Y2Sap
   # Module for the global variables in the Y2SAP::Products class
   module ProductsVariables


### PR DESCRIPTION
- So ` y2makepot` does not complain anymore
- The translatable texts are now extracted to `sap-installation-wizard.pot` file