### PR TITLE
sap-installation-wizard must not require HA and SLE4SAP packages

### DIFF
--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Thu Feb  9 09:54:40 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 
-- Do not require packages from HA and SLES4SAP. This packages are
-  only suggested. (bsc#1208112)
+- Do not require packages from HA and SLES4SAP. These packages are
+  only recommended. (bsc#1208112)
 - Fix unset local variable
 - Fix B1.xml
 - 4.5.2

--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -4,6 +4,7 @@ Thu Feb  9 09:54:40 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 - Do not require packages from HA and SLES4SAP. This packages are
   only suggested.
 - Fix unset local variable
+- Fix B1.xml
 - 4.5.2
 
 -------------------------------------------------------------------

--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -2,7 +2,7 @@
 Thu Feb  9 09:54:40 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 
 - Do not require packages from HA and SLES4SAP. This packages are
-  only suggested.
+  only suggested. (bsc#1208112)
 - Fix unset local variable
 - Fix B1.xml
 - 4.5.2

--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb  9 09:54:40 UTC 2023 - Peter Varkoly <varkoly@suse.com>
+
+- Do not require packages from HA and SLES4SAP. This packages are
+  only suggested.
+- Fix unset local variable
+- 4.5.2
+
+-------------------------------------------------------------------
 Fri Jan 20 09:40:32 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 
 - Implementing: Automatic Setup for SAP BusinessOne

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -28,13 +28,13 @@ Requires:       autoyast2
 Requires:       autoyast2-installation
 Requires:       rubygem(%{rb_default_ruby_abi}:nokogiri)
 Requires:     	xfsprogs
-Suggests:       HANA-Firewall
+Recommends:     HANA-Firewall
+Recommends:     saptune
 Suggests:       sap-netscape-link
 Suggests:       saprouter-systemd
 Suggests:       yast2-hana-firewall
 Suggests:       yast2-sap-scp
 Suggests:       yast2-sap-scp-prodlist
-Suggests:       saptune
 Source:         %{name}-%{version}.tar.bz2
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:	rubygem(%{rb_default_ruby_abi}:nokogiri)

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -22,7 +22,7 @@ License:        GPL-2.0+
 Group:          System/YaST
 Version:        4.5.2
 Release:        0
-PreReq:         /bin/mkdir %insserv_prereq %fillup_prereq yast2
+PreReq:         /bin/mkdir %fillup_prereq yast2
 BuildRequires:  yast2
 Requires:       autoyast2
 Requires:       autoyast2-installation

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -20,23 +20,21 @@ Name:           sap-installation-wizard
 Summary:        Installation wizard for SAP applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 PreReq:         /bin/mkdir %insserv_prereq %fillup_prereq yast2
 BuildRequires:  yast2
-Requires:       HANA-Firewall
 Requires:       autoyast2
 Requires:       autoyast2-installation
 Requires:       rubygem(%{rb_default_ruby_abi}:nokogiri)
 Requires:     	xfsprogs
-%if ! %{defined _SAPBOne}
-Requires:       sap-netscape-link
-Requires:       saprouter-systemd
-Requires:       yast2-hana-firewall
-Requires:       yast2-sap-scp
-Requires:       yast2-sap-scp-prodlist
-Requires:       saptune
-%endif
+Suggests:       HANA-Firewall
+Suggests:       sap-netscape-link
+Suggests:       saprouter-systemd
+Suggests:       yast2-hana-firewall
+Suggests:       yast2-sap-scp
+Suggests:       yast2-sap-scp-prodlist
+Suggests:       saptune
 Source:         %{name}-%{version}.tar.bz2
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  ruby2.5-stdlib

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -37,8 +37,7 @@ Suggests:       yast2-sap-scp-prodlist
 Suggests:       saptune
 Source:         %{name}-%{version}.tar.bz2
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildRequires:  ruby2.5-stdlib
-BuildRequires:	ruby2.5-rubygem-nokogiri
+BuildRequires:	rubygem(%{rb_default_ruby_abi}:nokogiri)
 BuildRequires:  autoyast2-installation
 BuildRequires:  yast2-network
 BuildRequires:  yast2-ruby-bindings >= 4.0.6

--- a/src/data/y2sap/B1.noask.xml
+++ b/src/data/y2sap/B1.noask.xml
@@ -9,9 +9,6 @@
     </mode>
   </general>
   <software>
-    <!-- post-patterns config:type="list">
-    <pattern>sap-b1</pattern>
-  </post-patterns -->
     <post-packages config:type="list">
       <package>patterns-sap-b1</package>
     </post-packages>

--- a/src/data/y2sap/B1.templ.xml
+++ b/src/data/y2sap/B1.templ.xml
@@ -41,61 +41,9 @@
   </ask-list>
 </general>
 <software>
-  <!-- post-patterns config:type="list">
-    <pattern>sap-b1</pattern>
-  </post-patterns -->
-  <post-packages config:type="list">
-	<package>bash</package>
-	<package>bind-utils</package>
-	<package>clamsap</package>
-	<package>coreutils</package>
-	<package>cron</package>
-	<package>cryptctl</package>
-	<package>curl</package>
-	<package>cyrus-sasl</package>
-	<package>gawk</package>
-	<package>glibc</package>
-	<package>glibc-i18ndata</package>
-	<package>glibc-locale</package>
-	<package>HANA-Firewall</package>
-	<package>keyutils-libs</package>
-	<package>krb5</package>
-	<package>libaio1</package>
-	<package>libcom_err2</package>
-	<package>libcurl4</package>
-	<package>libgcrypt20</package>
-	<package>libexpat1</package>
-	<package>libgcc_s1</package>
-	<package>libgpg-error0</package>
-	<package>libgthread-2_0-0</package>
-	<package>libldap-2_4-2</package>
-	<package>libopenssl0_9_8</package>
-	<package>libstdc++6</package>
-	<package>libxml2-tools</package>
-	<package>net-tools</package>
-	<package>nfs-kernel-server</package>
-	<package>openssl</package>
-	<package>pam</package>
-	<package>perl</package>
-	<package>python</package>
-	<package>rpm-build</package>
-	<package>samba</package>
-	<package>samba-client</package>
-	<package>SAPHanaSR</package>
-	<package>sap-installation-wizard</package>
-	<package>sap-netscape-link</package>
-	<package>saprouter-systemd</package>
-	<package>saptune</package>
-	<package>sles4sap-white-papers</package>
-	<package>SuSEfirewall2</package>
-	<package>timezone</package>
-	<package>unzip</package>
-	<package>yast2-hana-firewall</package>
-	<package>yast2-sap-ha</package>
-	<package>yast2-sap-scp</package>
-	<package>yast2-sap-scp-prodlist</package>
-	<package>zip</package>
-	<package>zlib</package>
+    <post-packages config:type="list">
+      <package>patterns-sap-b1</package>
+    </post-packages>
   </post-packages>
 </software>
   <networking>

--- a/src/data/y2sap/HANA.xml
+++ b/src/data/y2sap/HANA.xml
@@ -154,9 +154,6 @@ check_masterpwd "$VAL"
     </ask-list>
   </general>
   <software>
-    <!-- post-patterns config:type="list">
-    <pattern>sap-hana</pattern>
-  </post-patterns -->
     <post-packages config:type="list">
       <package>patterns-sap-hana</package>
     </post-packages>

--- a/src/lib/y2sap/media/check.rb
+++ b/src/lib/y2sap/media/check.rb
@@ -38,14 +38,14 @@ module Y2Sap
           fields = line.split(" ") if filepath[-1] == "info.txt"
           log.info("is_instmaster,search_labelfiles,fields: #{fields} size #{fields.size}")
           next if fields.size == 0
-          instmaster = check_label(fields)
+          instmaster = check_label(fields,label_file)
           return instmaster if !instmaster.nil?
         end
       end
       return instmaster
     end
 
-    def check_label(fields)
+    def check_label(fields,label_file)
       instmaster = []
       if fields[1] =~ /^HANA/
         instmaster[0] = "HANA"

--- a/src/lib/y2sap/media/check.rb
+++ b/src/lib/y2sap/media/check.rb
@@ -38,14 +38,14 @@ module Y2Sap
           fields = line.split(" ") if filepath[-1] == "info.txt"
           log.info("is_instmaster,search_labelfiles,fields: #{fields} size #{fields.size}")
           next if fields.size == 0
-          instmaster = check_label(fields,label_file)
+          instmaster = check_label(fields, label_file)
           return instmaster if !instmaster.nil?
         end
       end
       return instmaster
     end
 
-    def check_label(fields,label_file)
+    def check_label(fields, label_file)
       instmaster = []
       if fields[1] =~ /^HANA/
         instmaster[0] = "HANA"

--- a/src/lib/y2sap/media/copy.rb
+++ b/src/lib/y2sap/media/copy.rb
@@ -40,7 +40,7 @@ module Y2Sap
         ""
       )
       Progress.NextStep
-      show_progress(pid, source_dir, target_dir, sub_dir)
+      show_progress(pid, source_dir, target_dir, sub_dir, source_size)
       # release the process from the agent
       SCR.Execute(path(".process.release"), pid)
       Progress.Finish
@@ -85,7 +85,7 @@ module Y2Sap
       end
     end
 
-    def show_progress(pid, source_dir, target_dir, sub_dir)
+    def show_progress(pid, source_dir, target_dir, sub_dir, source_size)
       while SCR.Read(path(".process.running"), pid) == true
         sleep(2)
         techsize = tech_size(target_dir + "/" + sub_dir)

--- a/src/lib/y2sap/partitioning/product_partitioning.rb
+++ b/src/lib/y2sap/partitioning/product_partitioning.rb
@@ -35,6 +35,7 @@ module Y2Sap
     include Yast::UIShortcuts
     def create_partitions(product_partitioning_list, product_list)
       log.info("********Starting partitioning with #{product_partitioning_list} #{product_list}")
+      ret=""
 
       hwinfo = hw_info
       manufacturer = Ops.get(hwinfo, 0, "") # "FUJITSU", "IBM", "HP", "Dell Inc."

--- a/src/lib/y2sap/partitioning/product_partitioning.rb
+++ b/src/lib/y2sap/partitioning/product_partitioning.rb
@@ -35,7 +35,7 @@ module Y2Sap
     include Yast::UIShortcuts
     def create_partitions(product_partitioning_list, product_list)
       log.info("********Starting partitioning with #{product_partitioning_list} #{product_list}")
-      ret=""
+      ret = ""
 
       hwinfo = hw_info
       manufacturer = Ops.get(hwinfo, 0, "") # "FUJITSU", "IBM", "HP", "Dell Inc."


### PR DESCRIPTION
## sap-installation-wizard must not require HA and SLE4SAP packages

*sap-installation-wizard since SLE15-SP5 will be available on normal SLES. Thats why sap-installation-wizard must not require HA and SLE4SAP packages.*


## Solution

*Adapt requirements*
*Furthermore some variable visability issue was fixed*
*Use pattern instead of package list in autoyast xml file.*