### PR TITLE
Fix bsc#1211099

### DIFF
--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 17 13:08:59 UTC 2023 - Peter Varkoly <varkoly@suse.com>
+
+- sap-installation-wizard crashes: logger.rb aborts with wrong number of arguments
+  (bsc#1211099)
+- 4.4.6 
+
+-------------------------------------------------------------------
 Thu Apr 13 16:57:37 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 
 - AUDIT-0: sap-installation-wizard: b-one stuff (bsc#1210043)

--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -3,7 +3,7 @@ Wed May 17 13:08:59 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 
 - sap-installation-wizard crashes: logger.rb aborts with wrong number of arguments
   (bsc#1211099)
-- 4.4.6 
+- 4.4.6
 
 -------------------------------------------------------------------
 Thu Apr 13 16:57:37 UTC 2023 - Peter Varkoly <varkoly@suse.com>

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -19,7 +19,7 @@ Name:           sap-installation-wizard
 Summary:        Installation wizard for SAP applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.4.5
+Version:        4.4.6
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 Requires:       autoyast2
@@ -60,7 +60,7 @@ Authors:
 Summary:        Installation wizard for SAP Business One applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.4.5
+Version:        4.4.6
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 BuildRequires:  yast2

--- a/src/lib/y2sap/partitioning/product_partitioning.rb
+++ b/src/lib/y2sap/partitioning/product_partitioning.rb
@@ -105,7 +105,7 @@ module Y2Sap
     def hw_info
       hwinfo = []
       bios = Convert.to_list(SCR.Read(path(".probe.bios")))
-      log.warn("Warning: BIOS list size is %1", Builtins.size(bios)) if bios.size != 1
+      log.warn(format("Warning: BIOS list size is %d", bios.size)) if bios.size != 1
       biosinfo = Ops.get_map(bios, 0, {})
       smbios = Ops.get_list(biosinfo, "smbios", [])
       sysinfo = {}


### PR DESCRIPTION
## Problem 

*sap-installation-wizard crashes: logger.rb aborts with wrong number of arguments.*

- *https://bugzilla.suse.com/show_bug.cgi?id=1211099*


## Solution

Fix call log.warn