### PR TITLE
Sle 15 sp4

### DIFF
--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -16,6 +16,12 @@ Tue Jun  6 09:37:49 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 - Do not create new package. Fit package dependency using the macro %sap_bone
 
 -------------------------------------------------------------------
+Sun Jun  4 07:31:07 UTC 2023 - Peter Varkoly <varkoly@suse.com>
+
+- bone-installation-wizard needs to provide sap-installation-wizard until
+  the installation-images will be rebuild with new sap-installation-wizard
+
+-------------------------------------------------------------------
 Wed May 17 13:08:59 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 
 - sap-installation-wizard crashes: logger.rb aborts with wrong number of arguments

--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -10,7 +10,7 @@ Wed Jun  7 09:43:29 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 - Remove all depreceted unified_installer stuff.
 - sap-installation-wizard can not find the installer on B1 image
   (bsc#1212097) Fix the order of finding the installer.
-- Add some Business One specific tunig stuff  which was earlier integrated into the preinstalled image.
+- Add some Business One specific tuning stuff  which was earlier integrated into the preinstalled image.
   sysconfig: pm-profiler, sapconf
   logrotate configuration
   systemd logind.conf.d

--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,4 +1,17 @@
 -------------------------------------------------------------------
+Wed Jun  7 09:43:29 UTC 2023 - Peter Varkoly <varkoly@suse.com>
+
+- Remove all depreceted unified_installer stuff.
+- sap-installation-wizard can not find the installer on B1 image
+  (bsc#1212097) Fix the order of finding the installer.
+- 4.4.7
+
+-------------------------------------------------------------------
+Tue Jun  6 09:37:49 UTC 2023 - Peter Varkoly <varkoly@suse.com>
+
+- Do not create new package. Fit package dependency using the macro %sap_bone
+
+-------------------------------------------------------------------
 Wed May 17 13:08:59 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 
 - sap-installation-wizard crashes: logger.rb aborts with wrong number of arguments

--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 15 14:05:22 UTC 2023 - Peter Varkoly <varkoly@suse.com>
+
+- Enable sapconf to apply the required system settings by start.
+- 4.4.8
+
+-------------------------------------------------------------------
 Wed Jun  7 09:43:29 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 
 - Remove all depreceted unified_installer stuff.

--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -4,6 +4,10 @@ Wed Jun  7 09:43:29 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 - Remove all depreceted unified_installer stuff.
 - sap-installation-wizard can not find the installer on B1 image
   (bsc#1212097) Fix the order of finding the installer.
+- Add some Business One specific tunig stuff  which was earlier integrated into the preinstalled image.
+  sysconfig: pm-profiler, sapconf
+  logrotate configuration
+  systemd logind.conf.d
 - 4.4.7
 
 -------------------------------------------------------------------

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -34,6 +34,9 @@ Requires:       saprouter-systemd
 Requires:       yast2-hana-firewall
 Requires:       yast2-sap-scp
 Requires:       yast2-sap-scp-prodlist
+%else
+Requires:       logrotate
+Requires:       sapconf
 %endif
 Source:         %{name}-%{version}.tar.bz2
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -76,6 +79,15 @@ ln -s sap_installation_wizard.rb sap-installation-wizard.rb
 
 %post
 %{fillup_only -n sap-installation-wizard}
+
+%post -n bone-installation-wizard
+%{fillup_only -n sap-installation-wizard}
+%if  %{defined sap_bone}
+%{fillup_only -n pm-profiler}
+%{fillup_only -n sapconf}
+cp /usr/share/YaST2/data/y2sap/logrotate-BOne /etc/logrotate.d/BOne
+cp /usr/share/YaST2/data/y2sap/logind.conf.d-sap.conf /etc/systemd/logind.conf.d/sap.conf
+%endif
 
 %preun
 

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -19,13 +19,14 @@ Name:           sap-installation-wizard
 Summary:        Installation wizard for SAP applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.4.6
+Version:        4.4.7
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 Requires:       autoyast2
 Requires:       autoyast2-installation
 Requires:       rubygem(%{rb_default_ruby_abi}:nokogiri)
 Requires:     	xfsprogs
+%if ! %{defined sap_bone}
 Requires:       HANA-Firewall
 Requires:       saptune
 Requires:       sap-netscape-link
@@ -33,6 +34,7 @@ Requires:       saprouter-systemd
 Requires:       yast2-hana-firewall
 Requires:       yast2-sap-scp
 Requires:       yast2-sap-scp-prodlist
+%endif
 Source:         %{name}-%{version}.tar.bz2
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  autoyast2-installation
@@ -45,34 +47,11 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  yast2-network
 BuildRequires:  yast2-ruby-bindings >= 4.0.6
 ExclusiveArch:  x86_64 ppc64le
-Conflicts:      bone-installation-wizard
 Obsoletes:      sap-media-changer <= 2.17
 Provides:       sap-media-changer  = %{version}
 
 %description
 A YaST module providing an installation wizard for SAP applications
-
-Authors:
---------
-    varkoly@suse.com
-
-%package -n bone-installation-wizard
-Summary:        Installation wizard for SAP Business One applications
-License:        GPL-2.0+
-Group:          System/YaST
-Version:        4.4.6
-Release:        0
-PreReq:         /bin/mkdir %fillup_prereq yast2
-BuildRequires:  yast2
-Requires:       autoyast2
-Requires:       autoyast2-installation
-Requires:       rubygem(%{rb_default_ruby_abi}:nokogiri)
-Requires:     	xfsprogs
-Conflicts:      sap-installation-wizard
-Provides:       sap-installation-wizard = %{version}
-
-%description -n bone-installation-wizard
-A YaST module providing an installation wizard for SAP BusinessOne
 
 Authors:
 --------
@@ -116,19 +95,6 @@ rm -rf  %{buildroot}
 %{yast_icondir}
 /usr/share/YaST2/data/y2sap/
 %doc src/docs/windows_cheat_sheet.pdf src/docs/sap-autoinstallation.txt src/docs/hana-autoyast.xml README README.md
-%license COPYING
-
-%files -n bone-installation-wizard
-%defattr(-,root,root)
-%{yast_clientdir}
-%{yast_libdir}
-%{yast_desktopdir}
-%{yast_fillupdir}
-%{yast_ybindir}
-%{yast_scrconfdir}
-%{yast_icondir}
-/usr/share/YaST2/data/y2sap/
-%doc README README.md
 %license COPYING
 
 %changelog

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -19,7 +19,7 @@ Name:           sap-installation-wizard
 Summary:        Installation wizard for SAP applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.4.7
+Version:        4.4.8
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 Requires:       autoyast2
@@ -82,6 +82,7 @@ ln -s sap_installation_wizard.rb sap-installation-wizard.rb
 %if  %{defined sap_bone}
 %{fillup_only -n pm-profiler}
 %{fillup_only -n sapconf}
+/usr/bin/systemctl enable sapconf
 cp /usr/share/YaST2/data/y2sap/logrotate-BOne /etc/logrotate.d/BOne
 mkdir -p /etc/systemd/logind.conf.d/
 cp /usr/share/YaST2/data/y2sap/logind.conf.d-sap.conf /etc/systemd/logind.conf.d/sap.conf

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -36,13 +36,14 @@ Requires:       yast2-sap-scp
 Requires:       yast2-sap-scp-prodlist
 %else
 PreReq:         logrotate
-Requires:       sapconf
+PreReq:         sapconf
 %endif
 Source:         %{name}-%{version}.tar.bz2
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  autoyast2-installation
 BuildRequires:	rubygem(%{rb_default_ruby_abi}:nokogiri)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
+BuildRequires:  sapconf
 BuildRequires:  yast2
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -1,5 +1,5 @@
 #
-# spec file for package sap-installation-wizard and bone-installation-wizard
+# spec file for package sap-installation-wizard
 #
 # Copyright (c) 2023 SUSE LINUX GmbH, Nuernberg, Germany.
 #
@@ -78,9 +78,6 @@ cd %{buildroot}/%{yast_clientdir}
 ln -s sap_installation_wizard.rb sap-installation-wizard.rb
 
 %post
-%{fillup_only -n sap-installation-wizard}
-
-%post -n bone-installation-wizard
 %{fillup_only -n sap-installation-wizard}
 %if  %{defined sap_bone}
 %{fillup_only -n pm-profiler}

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -35,7 +35,7 @@ Requires:       yast2-hana-firewall
 Requires:       yast2-sap-scp
 Requires:       yast2-sap-scp-prodlist
 %else
-Requires:       logrotate
+PreReq:         logrotate
 Requires:       sapconf
 %endif
 Source:         %{name}-%{version}.tar.bz2
@@ -83,6 +83,7 @@ ln -s sap_installation_wizard.rb sap-installation-wizard.rb
 %{fillup_only -n pm-profiler}
 %{fillup_only -n sapconf}
 cp /usr/share/YaST2/data/y2sap/logrotate-BOne /etc/logrotate.d/BOne
+mkdir -p /etc/systemd/logind.conf.d/
 cp /usr/share/YaST2/data/y2sap/logind.conf.d-sap.conf /etc/systemd/logind.conf.d/sap.conf
 %endif
 

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -69,6 +69,7 @@ Requires:       autoyast2-installation
 Requires:       rubygem(%{rb_default_ruby_abi}:nokogiri)
 Requires:     	xfsprogs
 Conflicts:      sap-installation-wizard
+Provides:       sap-installation-wizard = %{version}
 
 %description -n bone-installation-wizard
 A YaST module providing an installation wizard for SAP BusinessOne

--- a/src/bin/hana_inst.sh
+++ b/src/bin/hana_inst.sh
@@ -246,14 +246,14 @@ hana_lcm_workflow()
    hana_setenv_lcm
 
    # Detect if it is a B1 installation
-   B1=$(find /data/SAP_INST/2/Instmaster/ -maxdepth 1 -type f -exec grep FOR.B1 {} \;)
+   B1=$(find ${SAPCD_INSTMASTER} -maxdepth 1 -type f -exec grep FOR.B1 {} \;)
    if [ -n "$B1" -a ! -d ${SAPCD_INSTMASTER}/SAP_HANA_DATABASE ]; then
      # Move the component directories into the first level
      find ${SAPCD_INSTMASTER}/DATA_UNITS/  -type d -name "SAP_HANA_*" -exec mv {} ${SAPCD_INSTMASTER}/ \;
    fi
    # Find the installer
    HDBLCM=$(find ${SAPCD_INSTMASTER} -name hdblcm | grep -m 1 -P 'DATABASE|SERVER')
-   HDBLCMDIR=$(dirname ${HDBLCM})
+   HDBLCMDIR=$(dirname "${HDBLCM}")
    if [ -z "${HDBLCM}" ]; then
      echo "Cannot find hdblcm" > ${MEDIA_TARGET}/installation_failed
      rc=1

--- a/src/bin/hana_inst.sh
+++ b/src/bin/hana_inst.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # hana_inst.sh - is a script used to install SAP HANA
 #
@@ -189,68 +189,6 @@ hana_setenv_lcm()
 EOF
 }
 
-
-hana_setenv_unified_installer()
-{
-  # there are two versions of the HANA Unified Installer response file
-  # Try the newer one if present
-  oldfile=${SAPCD_INSTMASTER}/DATA_UNITS/HANA_IM_LINUX__${ARCH}/setuphana.slmodel.template
-  newfile=${oldfile}.v2
-  if [ -f ${newfile} ]; then
-    FILE=${newfile}
-
-    oldstring="<dataPath></dataPath>"
-    newstring="<dataPath>${hanadatadir}/${SID}</dataPath>"
-    sed -i "s@${oldstring}@${newstring}@" ${FILE}
-
-    oldstring="<logPath></logPath>"
-    newstring="<logPath>${hanalogdir}/${SID}</logPath>"
-    sed -i "s@${oldstring}@${newstring}@" ${FILE}
-
-    oldstring="<sapmntPath>/hanamnt</sapmntPath>"
-    newstring="<sapmntPath>/hana/shared</sapmntPath>"
-    sed -i "s@${oldstring}@${newstring}@" ${FILE}
-
-    oldstring="<instanceNumber></instanceNumber>"
-    newstring="<instanceNumber>${SAPINSTNR}</instanceNumber>"
-    sed -i "s@${oldstring}@${newstring}@" ${FILE}
-
-    oldstring="<sid></sid>"
-    newstring="<sid>${SID}</sid>"
-    sed -i "s@${oldstring}@${newstring}@" ${FILE}
-
-    oldstring="<hdbHost></hdbHost>"
-    newstring="<hdbHost>$(hostname -f)</hdbHost>"
-    sed -i "s@${oldstring}@${newstring}@" ${FILE}
-  else
-    FILE=${oldfile}
-
-    oldstring='${DATAPATH}'
-    newstring=${hanadatadir}/${SID}
-    sed -i "s@${oldstring}@${newstring}@" ${FILE}
-
-    oldstring='${LOGPATH}'
-    newstring=${hanalogdir}/${SID}
-    sed -i "s@${oldstring}@${newstring}@" ${FILE}
-
-    oldstring='/hanamnt'
-    newstring='/hana/shared'
-    sed -i "s@${oldstring}@${newstring}@" ${FILE}
-
-    oldstring='${INSTANCENUMBER}'
-    newstring=${SAPINSTNR}
-    sed -i "s@${oldstring}@${newstring}@" ${FILE}
-
-    oldstring='${SID}'
-    newstring=${SID}
-    sed -i "s@${oldstring}@${newstring}@" ${FILE}
-
-    oldstring='${HDBHOST}'
-    newstring=$(hostname -f)
-    sed -i "s@${oldstring}@${newstring}@" ${FILE}
-  fi
-}
-
 cleanup() {
   if [ ! -e /root/hana-install-do-not-rm ]; then
     # Cleanup
@@ -307,10 +245,19 @@ hana_lcm_workflow()
    hana_get_input
    hana_setenv_lcm
 
-   #Detect if it is a B1 installation
-   B1=$(grep "FOR.B1" ${SAPCD_INSTMASTER}/*)
+   # Detect if it is a B1 installation
+   B1=$(find /data/SAP_INST/2/Instmaster/ -maxdepth 1 -type f -exec grep FOR.B1 {} \;)
    if [ -n "$B1" -a ! -d ${SAPCD_INSTMASTER}/SAP_HANA_DATABASE ]; then
+     # Move the component directories into the first level
      find ${SAPCD_INSTMASTER}/DATA_UNITS/  -type d -name "SAP_HANA_*" -exec mv {} ${SAPCD_INSTMASTER}/ \;
+   fi
+   # Find the installer
+   HDBLCM=$(find ${SAPCD_INSTMASTER} -name hdblcm | grep -m 1 -P 'DATABASE|SERVER')
+   HDBLCMDIR=$(dirname ${HDBLCM})
+   if [ -z "${HDBLCM}" ]; then
+     echo "Cannot find hdblcm" > ${MEDIA_TARGET}/installation_failed
+     rc=1
+     return $rc
    fi
    case $A_SAPMDC in
      no)
@@ -353,54 +300,6 @@ hana_lcm_workflow()
    return $rc
 }
 
-hana_unified_installer_workflow()
-{
-   WORKDIR=/var/tmp/hanainst
-   DB_USER=SYSTEM
-   rm -rf ${WORKDIR}
-   mkdir -p ${WORKDIR}
-   hana_volumes
-   hana_get_input
-   hana_setenv_unified_installer
-
-   oldfile=${SAPCD_INSTMASTER}/DATA_UNITS/HANA_IM_LINUX__${ARCH}/setuphana.slmodel.template
-   newfile=${oldfile}.v2
-   if [ -f ${newfile} ]; then
-     FILE=${newfile}
-   else
-     FILE=${oldfile}
-   fi
-
-   LINUX26_SUPPORT=/usr/bin/uname26  # workaround for saposcol bug (does not detect Linux kernel 3.x which is shipped with SLES11 SP2)
-   echo -e "$(cat ${MEDIA_TARGET}/ay_q_masterPwd)\n$(cat ${MEDIA_TARGET}/ay_q_masterPwd)" | ${LINUX26_SUPPORT} ${MEDIA_TARGET}/Instmaster/DATA_UNITS/HANA_IM_LINUX__${ARCH}/setup.sh ${WORKDIR} ${FILE}
-   # Unified Installer always returns rc 0, regardless of success :-(
-   # workaround: test connection to HANA to determine success
-   [ -f ${A_SID} ] && SID=$(cat ${A_SID})
-   SID=${SID:="NDB"}
-   sid=${SID,,}
-   su - ${sid}adm -c "hdbsql -i ${SAPINSTNR} -u ${DB_USER} -p ${MASTERPASS} -jC 'select * from sys.dummy'" > /dev/null >&2
-   rc=$?
-
-   # install AFL (required for B1)
-   cd ${MEDIA_TARGET}/Instmaster/DATA_UNITS/HDB_AFL_LINUX_${ARCH}
-   if [ $? -eq 0 ]; then
-      ${MEDIA_TARGET}/Instmaster/DATA_UNITS/HANA_IM_LINUX__${ARCH}/SAPCAR -xvf ${MEDIA_TARGET}/Instmaster/DATA_UNITS/HDB_AFL_LINUX_${ARCH}/IMDB_AFL100_*.SAR
-      if [ $? -eq 0 ]; then
-          cd SAP_HANA_AFL
-          ./hdbinst -b -p $(cat ${MEDIA_TARGET}/ay_q_masterPwd) -s ${SID}
-          rc=$?
-          if [ $rc -ne 0 ]; then
-             echo "could not install AFL, error=$rc"
-          fi
-      else
-         echo "could not extract ${MEDIA_TARGET}/Instmaster/DATA_UNITS/HDB_AFL_LINUX_${ARCH}/IMDB_AFL100_*.SAR"
-      fi
-   else
-      echo "AFL directory ${MEDIA_TARGET}/Instmaster/DATA_UNITS/HDB_AFL_LINUX_${ARCH} does not exist"
-      rc=1
-   fi
-   return $rc
-}
 
 extract_media_archives()
 {
@@ -420,25 +319,8 @@ extract_media_archives()
 
 rc=0
 missing=''
-# determine proper installation tool:
-# HANA 1.0 <= SP6: Unified Installer
-# HANA 1.0 => SP7: Life Cycle Manager (hdblcm)
 extract_media_archives
-HDBLCM=$(find ${SAPCD_INSTMASTER} -name hdblcm | grep -m 1 -P 'DATABASE|SERVER')
-if [ -n "${HDBLCM}" ]; then
-   export HDBLCMDIR=$(dirname ${HDBLCM})
-   hana_lcm_workflow
-else
-   COMPONENTS="HANA_IM_LINUX__${ARCH} HDB_CLIENT_LINUX_${ARCH} HDB_SERVER_LINUX_${ARCH} SAP_HOST_AGENT_LINUX_X64 HDB_AFL_LINUX_${ARCH} HDB_STUDIO_LINUX_${ARCH} HDB_CLIENT_LINUXINTEL"
-   missing=$(hana_check_components)
-   if [ -n "${missing}" ]; then
-      echo "Cannot install, HANA component folders missing on media: ${missing}" > ${MEDIA_TARGET}/installation_failed
-      rc=1
-   else
-      hana_unified_installer_workflow
-      rc=$?
-   fi
-fi
+hana_lcm_workflow
 if [ $rc -eq 0 ]; then
    hana_installation_summary
 fi

--- a/src/data/y2sap/logind.conf.d-sap.conf
+++ b/src/data/y2sap/logind.conf.d-sap.conf
@@ -1,0 +1,3 @@
+[Login]
+UserTasksMax=infinity
+

--- a/src/data/y2sap/logrotate-BOne
+++ b/src/data/y2sap/logrotate-BOne
@@ -1,0 +1,63 @@
+################################################ 
+#
+### logrotate file for SAP BusinessOne
+#
+################################################ 
+#
+## For tomcat logs with own logrotate (<YYYY>-<MM>-<DD>)
+## we only can do compress and delete 
+#
+/opt/sap/SAPBusinessOne/tomcat/logs/IMCE*.log /opt/sap/SAPBusinessOne/tomcat/logs/analyticService*.log /opt/sap/SAPBusinessOne/tomcat/logs/host-manager*.log /opt/sap/SAPBusinessOne/tomcat/logs/localhost*.log /root/IMCE*.log {
+# suppress error if not exist
+   missingok
+# compress the logs
+   compress
+   compresscmd /usr/bin/xz
+   compressext .xz
+# remove  logs after 3 month
+   maxage 90
+}
+
+## BOne 9x has some new locations so we add it
+/opt/sap/SAPBusinessOne/Common/tomcat/logs/AnalyticsPlatform/IMCE*.log /opt/sap/SAPBusinessOne/Common/tomcat/logs/analyticService*.log /opt/sap/SAPBusinessOne/Common/tomcat/logs/catalina*.log /opt/sap/SAPBusinessOne/Common/tomcat/logs/host-manager*.log /opt/sap/SAPBusinessOne/Common/tomcat/logs/localhost*.log /opt/sap/SAPBusinessOne/Common/tomcat/logs/manager*.log /opt/sap/SAPBusinessOne/Common/tomcat/logs/sbomailer*.log /opt/sap/SAPBusinessOne/Common/tomcat/logs/security*.log /opt/sap/SAPBusinessOne/Common/tomcat/logs/sldService*.log{
+# suppress error if not exist
+   missingok
+# compress the logs
+   compress
+   compresscmd /usr/bin/xz
+   compressext .xz
+# remove  logs after 3 month
+   maxage 90
+}
+
+## BOne 9x has some new locations so we add it
+/usr/sap/SAPBusinessOne/Common/tomcat/logs/AnalyticsPlatform/IMCE*.log /usr/sap/SAPBusinessOne/Common/tomcat/logs/analyticService*.log /usr/sap/SAPBusinessOne/Common/tomcat/logs/catalina*.log /usr/sap/SAPBusinessOne/Common/tomcat/logs/host-manager*.log /usr/sap/SAPBusinessOne/Common/tomcat/logs/localhost*.log /usr/sap/SAPBusinessOne/Common/tomcat/logs/manager*.log /usr/sap/SAPBusinessOne/Common/tomcat/logs/sbomailer*.log /usr/sap/SAPBusinessOne/Common/tomcat/logs/security*.log /usr/sap/SAPBusinessOne/Common/tomcat/logs/sldService*.log{
+# suppress error if not exist
+   missingok
+# compress the logs
+   compress
+   compresscmd /usr/bin/xz
+   compressext .xz
+# remove  logs after 3 month
+   maxage 90
+}
+
+#
+## For normal log file we can rotate
+#
+/root/SAP_Business_One /root/analytics_powered_by_SAP_HANA_Install* {
+# suppress error if not exist
+   missingok
+# rotate the log every month
+   monthly
+# keep 3 rotated logs
+   rotate 3
+# compress the archived logs
+   compress
+   compresscmd /usr/bin/xz
+   compressext .xz
+# remove rotated logs after 3 month
+   maxage 90
+# rotate if bigger than
+   size=+2048k
+}

--- a/src/fillup/sysconfig.pm-profiler
+++ b/src/fillup/sysconfig.pm-profiler
@@ -1,0 +1,21 @@
+## Path:	 Hardware/Power
+## Description:	 Defines a Power Management profile to use
+## Type:	 string
+## Default:	 ""
+#
+# Defines the profile which gets activated on system start or
+# Path:         Hardware/Power
+## Description:  Defines a Power Management profile to use
+## Type:         string
+## Default:      ""
+#
+# Defines the profile which gets activated on system start or
+# when the pm-profile service gets restarted
+# pm-profiler, and thus this file, is not intended to be used on desktop
+# systems where power management policy managers like gnome-power-manager,
+# power-devil, etc. exist. pm-profiler is only intended for servers
+# with dedicated use cases
+# If empty, the default system/kernel settings will be used.
+# Possible values: 1. Profile name
+#                  2. Empty
+PM_PROFILER_PROFILE="low_latency"

--- a/src/fillup/sysconfig.sapconf
+++ b/src/fillup/sysconfig.sapconf
@@ -1,0 +1,319 @@
+## Path:	Productivity/Other
+## Description: Limits for system tuning profiles of sapconf
+## ServiceRestart: sapconf
+##
+## This file includes parameters recommended by SAP
+## Be in mind: If you edit or remove values from this file, sapconf will no
+## long behave as designed to or monitor these removed parameters
+##
+## This file is sourced in the common script (lib/common.sh) of sapconf and
+## in sapconf (lib/sapconf) itself.
+## SCCU2
+##
+# Size of tmpfs mounted on /dev/shm in percent of the virtual memory.
+# Depending on the size of the virtual memory (physical+swap) the
+# value is calculated by (RAM + SWAP) * VSZ_TMPFS_PERCENT/100
+# Set to 75
+#
+# SAP Note 941735
+#
+VSZ_TMPFS_PERCENT=75
+
+# kernel.shmall
+# This parameter sets the total amount of shared memory pages that
+# can be used system wide. Hence, SHMALL should always be at least
+# ceil(shmmax/PAGE_SIZE).
+# To determine the current page size run the command "getconf PAGE_SIZE".
+# see https://www.kernel.org/doc/Documentation/sysctl/kernel.txt
+#
+# kernel.shmall is set to the SHMALL value from this file
+#
+# SAP Note 941735, HANA Administration Guide
+# 
+SHMALL=1152921504606846720
+
+# kernel.shmmax
+# This value can be set the run time limit on the maximum shared memory
+# segment size that can be created.
+# see https://www.kernel.org/doc/Documentation/sysctl/kernel.txt
+#
+# kernel.shmmax is set to the SHMMAX value from this file
+#
+# SHMMAX set to ULONG_MAX (18446744073709551615)
+#
+# SAP Note 941735, HANA Administration Guide
+#
+SHMMAX=18446744073709551615
+
+# /etc/security/limits.d/sapconf-nofile.conf
+## Type:        regexp(^@(sapsys|sdba|dba)[[:space:]]+(-|hard|soft)[[:space:]]+(nofile)[[:space:]]+[[:digit:]]+)
+#
+# Maximum number of open files for SAP application groups sapsys, sdba, and dba.
+# Consult with manual page limits.conf(5) for the correct syntax.
+# Set to 65536
+#
+# SAP Note 1771258
+#
+LIMIT_1="@sapsys soft nofile 65536"
+LIMIT_2="@sapsys hard nofile 65536"
+LIMIT_3="@sdba soft nofile 65536"
+LIMIT_4="@sdba hard nofile 65536"
+LIMIT_5="@dba soft nofile 65536"
+LIMIT_6="@dba hard nofile 65536"
+
+# vm.max_map_count
+# The value is the maximum number of memory map areas a process may have.
+# Memory map areas are used as a side-effect of calling malloc, directly by
+# mmap and mprotect, and also when loading shared libraries.
+#
+# vm.max_map_count is set to the MAX_MAP_COUNT value from this file
+#
+# vm.max_map_count should be set to MAX_INT (2147483647)
+#
+# SAP Note 1980196, 900929, HANA Administration Guide
+#
+MAX_MAP_COUNT=2147483647
+
+# kernel.shmmni
+# The value is the maximum number of shared memory identifies available in the
+# system.
+#
+# kernel.shmmni is set to the SHMMNI value from this file
+#
+# kernel.shmmni should be set to 32768
+#
+# SAP Note 2534844, HANA Administration Guide
+#
+SHMMNI=32768
+
+# vm.dirty_bytes (indirect vm.dirty_ratio)
+# Contains the amount of dirty memory at which a process generating disk writes
+# will itself start writeback.
+# Note: dirty_bytes is the counterpart of dirty_ratio. Only one of them may be
+# specified at a time. When one sysctl is written it is immediately taken into
+# account to evaluate the dirty memory limits and the other appears as 0 when
+# read.
+# Note: when switching off (stopping) sapconf, both values will be set back to
+# their previous settings.
+# Note: the minimum value allowed for dirty_bytes is two pages (in bytes); any
+# value lower than this limit will be ignored and the old configuration will be
+# retained.
+#
+# vm.dirty_bytes is set to the DIRTY_BYTES value from this file
+#
+# vm.dirty_bytes should be set to 629145600 (see TID_7010287)
+#
+# SAP Note 2578899
+#
+DIRTY_BYTES=629145600
+
+# vm.dirty_background_bytes (indirect vm.dirty_background_ratio)
+# Contains the amount of dirty memory at which the background kernel
+# flusher threads will start writeback.
+# Note: dirty_background_bytes is the counterpart of dirty_background_ratio.
+# Only one of them may be specified at a time. When one sysctl is written it is
+# immediately taken into account to evaluate the dirty memory limits and the
+# other appears as 0 when read.
+# Note: when switching off (stopping) sapconf, both values will be set back to
+# their previous settings.
+#
+# vm.dirty_background_bytes is set to the DIRTY_BG_BYTES value from this file
+#
+# vm.dirty_background_bytes should be set to 314572800 (see TID_7010287)
+#
+# SAP Note 2578899
+#
+DIRTY_BG_BYTES=314572800
+
+# net.ipv4.tcp_slow_start_after_idle
+# If enabled (=1), provide RFC 2861 behavior and time out the congestion
+# window after an idle period. An idle period is defined as the current
+# RTO (retransmission timeout). If disabled (=0), the congestion window will
+# not be timed out after an idle period.
+#
+# This value is important for large ScaleOut HANA clusters and HANA2 in general.
+# So disable TCP slow start on idle connections
+# set net.ipv4.tcp_slow_start_after_idle=0
+#
+# SAP Note 2382421
+#
+TCP_SLOW_START=0
+
+# /sys/kernel/mm/ksm/run
+# Kernel Samepage Merging (KSM). KSM allows for an application to register with
+# the kernel so as to have its memory pages merged with other processes that
+# also register to have their pages merged. For KVM the KSM mechanism allows
+# for guest virtual machines to share pages with each other. In todays
+# environment where many of the guest operating systems like XEN, KVM are
+# similar and are running on same host machine, this can result in significant
+# memory savings. Default value is 0.
+#
+# ksm set to 0
+#
+# SAP Note 2684254
+#
+KSM=0
+
+# /proc/sys/kernel/numa_balancing
+# Enables/disables automatic page fault based NUMA memory balancing.
+# Memory is moved automatically to nodes that access it often.
+# Enables/disables automatic NUMA memory balancing. On NUMA machines, there
+# is a performance penalty if remote memory is accessed by a CPU. When this
+# feature is enabled the kernel samples what task thread is accessing memory
+# by periodically unmapping pages and later trapping a page fault. At the
+# time of the page fault, it is determined if the data being accessed should
+# be migrated to a local memory node.
+# The unmapping of pages and trapping faults incur additional overhead that
+# ideally is offset by improved memory locality but there is no universal
+# guarantee. If the target workload is already bound to NUMA nodes then this
+# feature should be disabled. Otherwise, if the system overhead from the
+# feature is too high then the rate the kernel samples for NUMA hinting
+# faults may be controlled by the numa_balancing_scan_period_min_ms,
+# numa_balancing_scan_delay_ms, numa_balancing_scan_period_max_ms,
+# numa_balancing_scan_size_mb, and numa_balancing_settle_count sysctls.
+#
+# Turn off autoNUMA balancing
+# 0 to disable, 1 to enable
+# numa_balancing set to 0
+#
+# SAP Note 2684254
+#
+NUMA_BALANCING=0
+
+# /sys/kernel/mm/transparent_hugepage/enabled
+#
+# 'never' to disable, 'always' to enable
+# Disable transparent hugepages
+# set to 'never'
+#
+# SAP Note 2131662, 2684254, 2031375
+#
+THP=never
+
+# Energy Performance Bias EPB (applies to Intel-based systems only)
+#
+# we renamed the parameter to PERF_BIAS to make a clear distinction to
+# the former used tuned.conf parameter 'energy_perf_bias'
+#
+# PERF_BIAS: performance - 0, normal - 6, powersave - 15
+# or any number between 0 and 15
+#
+# SAP Note 2684254
+#
+# setting is disabled by default (leave empty)
+# When set, for all cpus the energy performance bias setting will be switched
+# to the chosen value.
+# if activating performance related settings a recommended value for
+# Energy Performance Bias is 'performance' or '0'
+#
+PERF_BIAS="performance"
+
+# CPU Frequency/Voltage scaling (applies to Intel-based systems only)
+#
+# we renamed the parameter to GOVERNOR to make a clear distinction to
+# the former used tuned.conf parameter 'governor'
+#
+# The clock frequency and voltage of modern CPUs can scale, in order to save
+# energy when there’s less work to be done. However HANA as a high-performance
+# database benefits from high CPU frequencies.
+# governor: performance , powersave
+#
+# SAP Note 2684254
+#
+# setting is disabled by default (leave empty)
+# When set, for all cpus the scaling governor setting will be switched to the
+# chosen value.
+# if activating performance related settings a recommended value for
+# governor is 'performance'
+#
+GOVERNOR="performance"
+
+# force latency - configure C-States for lower latency
+# (applies to Intel-based systems only)
+#
+# we renamed the parameter to FORCE_LATENCY to make a clear distinction to
+# the former used tuned.conf parameter 'force_latency'
+#
+# Input is a string, which is internally treated as a decimal (not a
+# hexadecimal) integer number representing a maximum response time in
+# microseconds.
+# It is used to establish a latency upper limit by limiting the use of C-States
+# (CPU idle or CPU latency states) to only those with an exit latency smaller
+# than the value set here. That means only those states that require less than
+# the requested number of microseconds to wake up are enabled, all the other
+# C-States are disabled.
+#
+# The files /sys/devices/system/cpu/cpu*/cpuidle/state*/latency and
+# /sys/devices/system/cpu/cpu*/cpuidle/state*/disable are used to limit the
+# C-States.
+#
+# When set in the sysconfig file
+# for all available CPUs all CPU latency states with a value read from
+# /sys/devices/system/cpu/cpu*/cpuidle/state*/latency >= (higher than)
+# the value from the sysconfig file are disabled by writing '1' to
+# /sys/devices/system/cpu/cpu*/cpuidle/state*/disable
+#
+# ATTENTION: not idling *at all* increases power consumption significantly and
+# reduces the life span of the machine because of wear and tear. So do not use
+# a too strict latency setting. For SAP HANA workloads a value of '70'
+# microseconds (as a "light sleep") seems to be sufficient. And the impact on
+# power consumption and life of the CPUs is less severe. But don't forget: The
+# deeper the idle state, the larger is the exit latency.
+#
+# SAP Note 2684254
+#
+# if activating performance related settings a recommended value for
+# force latency to start with is 70
+#
+FORCE_LATENCY=70
+
+# Intel P-State driver setting
+# (applies to Intel-based systems only and only if Intel-P-State-Driver is used)
+#
+# we renamed the parameter to MIN_PERF_PCT to make a clear distinction to
+# the former used tuned.conf parameter 'min_perf_pct'
+#
+# The P-State driver provides its own sysfs files to control the P-State
+# selection. These files have been added to /sys/devices/system/cpu/intel_pstate
+# Any changes made to these files are applicable to all CPUs
+#
+# min_perf_pct: Limits the minimum P-State that will be requested by the driver.
+# It states it as a percentage of the max (non-turbo) performance level.
+#
+# SAP Note 2684254
+#
+# setting is disabled by default (leave empty)
+# if activating performance related settings a recommended value for
+# MIN_PERF_PCT to start with is 100
+#
+MIN_PERF_PCT=
+
+# disk I/O scheduler
+#
+# we renamed the parameter to IO_SCHEDULER to make a clear distinction to
+# the former used tuned.conf parameter 'elevator'
+#
+# The default I/O scheduler for single-queued block layer devices offers
+# satisfactory performance for wide range of I/O task, however choosing an
+# alternative scheduler may potentially yield better latency characteristics
+# and throughput.
+# "noop" is an alternative scheduler, in comparison to other schedulers it
+# may offer more consistent performance, lower computation overhead, and
+# potentially higher throughput.
+# For most SAP environments (RAID, storage arrays, virtualizaton) 'noop' is
+# the better choice.
+# With the new introduced multi-queue scheduler for block layer devices the
+# recommended I/O scheduler is 'none' as an equivalent to 'noop' for
+# single-queued block layer devices.
+#
+# So IO_SCHEDULER can now contain a list of possible schedulers, separated
+# by blanks, which are checked from left to right. The first one which is
+# available in /sys/block/<device>/queue/scheduler will be used as new
+# scheduler setting for the respective block device.
+#
+# When set, all block devices on the system will be switched to one of the
+# chosen schedulers.
+#
+# SAP Note 2578899
+#
+IO_SCHEDULER="noop none"


### PR DESCRIPTION
## Problem

Recreating reviewed pull request. (#16)

## Problem

*Splitting this package on SLE 15 SP4 causes some additional problems.*
*We have to provide some system adaption for SAP Business One systems which was earlier done by the image deployment."*
*hana_inst.sh can not detect Business One media in some cases.*

- *bsc#1212097*

## Solution

* Do not split the package. We build sap-installation-wizard in a separate repository for the SLE-Module-Business-One.: SUSE:SLE-15-SP4:Update:SAPBOne In this repository the macro %sap_bone is defined. This will be used to trigger SAP-BOne stuff.
* Add logrotate, sapconf, systemd handlind which was present in the prelaoded image util SLE-15-SP2.
* Adapt hana_inst.sh. Remove deprecated not used stuff.


