### PR TITLE
openQA test fails

### DIFF
--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Mar  5 14:45:24 UTC 2024 - Peter Varkoly <varkoly@suse.com>
+
+- [Build 60.3] openQA test fails in "autoyast_sles4sap_hana" autoyast installation, it reports : Value '' is invalid. Use one of: ports, hostnames
+  (bsc#1220851)
+- bone-installation-wizard must not require patterns-sap-hana. This is only available for SLE4SAP product
+- 4.6.12
+
+-------------------------------------------------------------------
 Tue Feb 27 16:43:56 UTC 2024 - Peter Varkoly <varkoly@suse.com>
 
 - SAP Business One: using hostname instead of IP address for SAP installation 

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -19,7 +19,7 @@ Name:           sap-installation-wizard
 Summary:        Installation wizard for SAP applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.6.11
+Version:        4.6.12
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 Requires:       autoyast2
@@ -60,14 +60,13 @@ Authors:
 Summary:        Installation wizard for SAP Business One applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.6.11
+Version:        4.6.12
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 BuildRequires:  yast2
 BuildRequires:  sapconf
 Requires:       autoyast2
 Requires:       autoyast2-installation
-Requires:       patterns-sap-hana
 Requires:       patterns-sap-bone
 Requires:       rubygem(%{rb_default_ruby_abi}:nokogiri)
 Requires:     	xfsprogs

--- a/src/bin/hana_inst.sh
+++ b/src/bin/hana_inst.sh
@@ -161,8 +161,8 @@ hana_get_input()
        echo "Warning: MASTERPASS not set!"
    fi
 
-   [ -f ${A_XS_DOMAIN_NAME} ]  && A_XS_DOMAIN_NAME=$(cat ${A_XS_DOMAIN_NAME})
-   [ -f ${A_XS_ROUTING_MODE} ] && A_XS_ROUTING_MODE=$(cat ${A_XS_ROUTING_MODE})
+   [ -f ${A_XS_DOMAIN_NAME} ]  && XS_DOMAIN_NAME=$(cat ${A_XS_DOMAIN_NAME})
+   [ -f ${A_XS_ROUTING_MODE} ] && XS_ROUTING_MODE=$(cat ${A_XS_ROUTING_MODE})
 }
 
 hana_setenv_lcm()
@@ -260,7 +260,7 @@ hana_lcm_workflow()
    if [ -e /root/hana-install-ignore ]; then
      TOIGNORE=$(cat /root/hana-install-ignore)
    fi
-   if [ ${XS_ROUTING_MODE} == "ports" ]; then
+   if [ -z "${XS_ROUTING_MODE}" -o -z "${XS_DOMAIN_NAME}" -o "${XS_ROUTING_MODE}" == "ports" ]; then
        cat ~/pwds.xml | ./hdblcm --batch --action=install \
             --ignore=$TOIGNORE \
             --lss_trust_unsigned_server \

--- a/src/bin/sap_inst.sh
+++ b/src/bin/sap_inst.sh
@@ -680,7 +680,7 @@ EOF
 
 
 cleanup() {
-  if [ ! -e /root/b1-install-do-not-rm ]; then
+  if [ ! -e /root/sap-install-do-not-rm ]; then
 
     # Cleanup
     # SAPINST automatically creates the directory /tmp/sapinst_exe.*

--- a/src/lib/y2sap/auto.rb
+++ b/src/lib/y2sap/auto.rb
@@ -168,6 +168,7 @@ module Y2Sap
     # Sets the global variables for a HANA installation evaluated
     # from the autoyast hash.
     def prepare_hana(prod)
+      log.info("prepare_hana #{prod}")
       @db           = "HANA"
       @product_name = @inst_master_type
       @product_id   = @inst_master_type
@@ -182,19 +183,20 @@ module Y2Sap
       if prod.key?("sapVirtHostname")
         File.write(@inst_dir + "/ay_q_virt_hostname", prod["sapVirtHostname"])
       end
-      xs_routing_mode = prod.key?("xsRoutingMode") ? prod.key?("xsRoutingMode") : "ports"
+      xs_routing_mode = prod.key?("xsRoutingMode") ? prod["xsRoutingMode"] : "ports"
       if !["hostname", "ports"].include?(xs_routing_mode)
-        Yast::Popup.Error("Bad XS routing mode: #{xs_routing_mode}. Provided values are 'hostname' or 'ports'")
+        Yast::Popup.Error("Bad XS routing mode: #{xs_routing_mode}. Supported values are 'hostname' or 'ports'")
         @error = true
         return :abort
       end
       if xs_routing_mode == "hostname" && !prod.key?("xsDomainName")
-        Yast::Popup.Error("If XS routing mode is set to hostname you have to define xsDomainName also")
+        Yast::Popup.Error("If XS routing mode is set to 'hostname' you have to define xsDomainName also")
         @error = true
         return :abort
       end
       File.write(@inst_dir + "/ay_q_xs_routing_mode", xs_routing_mode)
       File.write(@inst_dir + "/ay_q_xs_domain_name", prod["xsDomainName"]) if prod.key?("xsDomainName")
+      log.info("prepare_hana XS routing #{xs_routing_mode}")
       @sid = prod["sid"]
       SCR.Execute(path(".target.bash"), "chgrp sapinst " + @inst_dir)
       SCR.Execute(path(".target.bash"), "chmod 775 " + @inst_dir)


### PR DESCRIPTION
## Problem

The new feature XS_ROUTIN_MODE coused some problems in autoinstallation.
Reason was some typo and bad logic.

patterns-sap-hana is not available for SLES. bone-installation-wizard is desined for SLES.

- *https://bugzilla.suse.com/show_bug.cgi?id=1220851*
- *https://openqa.suse.de/tests/13548816*

## Solution

*Fix auto.rb module an hana_inst.sh script.*
*Remove bad requirement.*

## Testing

- *Tested manually on gollum-p1.sap.prg2.suse.org*
