### PR TITLE
Fix bsc#1184679 openQA test fails in wizard_hana_install - Crash of Gnome session

### DIFF
--- a/asks/create_products_xml.sh
+++ b/asks/create_products_xml.sh
@@ -10,9 +10,8 @@ echo '<?xml version="1.0"?>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 <general>
   <mode>
-    <final_restart_services config:type="boolean">
-      false
-    </final_restart_services>
+    <final_restart_services config:type="boolean">false</final_restart_services>
+    <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
   </mode>
   <ask-list config:type="list">
   ' > $XMLFILE
@@ -80,6 +79,7 @@ else
 fi
 echo '  <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately>
   </networking>
 </profile>' >> $XMLFILE
 #now we check if it is OK

--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue May 21 09:30:08 UTC 2024 - Peter Varkoly <varkoly@suse.com>
+
+- openQA test fails in wizard_hana_install - Crash of Gnome session
+  (bsc#1184679)
+  Apply proposed ayast parameters:
+    general.mode.activate_systemd_default_target = false
+    networking.start_immediately =false
+- 4.6.14 
+
+-------------------------------------------------------------------
 Mon Apr  8 10:12:22 UTC 2024 - Peter Varkoly <varkoly@suse.com>
 
 - sap-installation-wizard install SPS05rev59 on ppc64le failed: Details: undefined method  for nil:NilClass

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -19,7 +19,7 @@ Name:           sap-installation-wizard
 Summary:        Installation wizard for SAP applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.6.13
+Version:        4.6.14
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 Requires:       autoyast2
@@ -60,7 +60,7 @@ Authors:
 Summary:        Installation wizard for SAP Business One applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.6.13
+Version:        4.6.14
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 BuildRequires:  yast2

--- a/src/data/y2sap/B1.noask.xml
+++ b/src/data/y2sap/B1.noask.xml
@@ -3,9 +3,8 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <general>
     <mode>
-      <final_restart_services config:type="boolean">
-        false
-      </final_restart_services>
+      <final_restart_services config:type="boolean">false</final_restart_services>
+      <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
     </mode>
   </general>
   <software>
@@ -15,5 +14,6 @@
   </software>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately>
   </networking>
 </profile>

--- a/src/data/y2sap/B1.templ.xml
+++ b/src/data/y2sap/B1.templ.xml
@@ -4,6 +4,7 @@
   <general>
     <mode>
       <final_restart_services config:type="boolean">false</final_restart_services>
+      <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
     </mode>
     <ask-list config:type="list">
       <ask>
@@ -54,5 +55,6 @@ exit $?
   </software>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately
   </networking>
 </profile>

--- a/src/data/y2sap/DIST-APP1.xml
+++ b/src/data/y2sap/DIST-APP1.xml
@@ -3,9 +3,8 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 <general>
   <mode>
-    <final_restart_services config:type="boolean">
-      false
-    </final_restart_services>
+    <final_restart_services config:type="boolean">false</final_restart_services>
+    <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
   </mode>
   <ask-list config:type="list">
   
@@ -296,5 +295,6 @@ check_instance_no "$VAL"
 </software>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately>
   </networking>
 </profile>

--- a/src/data/y2sap/DIST-ASCS.xml
+++ b/src/data/y2sap/DIST-ASCS.xml
@@ -3,9 +3,8 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 <general>
   <mode>
-    <final_restart_services config:type="boolean">
-      false
-    </final_restart_services>
+    <final_restart_services config:type="boolean">false</final_restart_services>
+    <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
   </mode>
   <ask-list config:type="list">
   
@@ -222,5 +221,6 @@ check_hostname "$VAL"
 </software>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately>
   </networking>
 </profile>

--- a/src/data/y2sap/DIST-DB.xml
+++ b/src/data/y2sap/DIST-DB.xml
@@ -3,9 +3,8 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 <general>
   <mode>
-    <final_restart_services config:type="boolean">
-      false
-    </final_restart_services>
+    <final_restart_services config:type="boolean">false</final_restart_services>
+    <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
   </mode>
   <ask-list config:type="list">
   
@@ -156,5 +155,6 @@ check_sid "$VAL"
 </software>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately>
   </networking>
 </profile>

--- a/src/data/y2sap/GATEWAY.xml
+++ b/src/data/y2sap/GATEWAY.xml
@@ -3,9 +3,8 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 <general>
   <mode>
-    <final_restart_services config:type="boolean">
-      false
-    </final_restart_services>
+    <final_restart_services config:type="boolean">false</final_restart_services>
+    <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
   </mode>
   <ask-list config:type="list">
   
@@ -21,5 +20,6 @@
 </software>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately>
   </networking>
 </profile>

--- a/src/data/y2sap/HA-ERS.xml
+++ b/src/data/y2sap/HA-ERS.xml
@@ -3,9 +3,8 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 <general>
   <mode>
-    <final_restart_services config:type="boolean">
-      false
-    </final_restart_services>
+    <final_restart_services config:type="boolean">false</final_restart_services>
+    <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
   </mode>
   <ask-list config:type="list">
   
@@ -21,5 +20,6 @@
 </software>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately>
   </networking>
 </profile>

--- a/src/data/y2sap/HANA.xml
+++ b/src/data/y2sap/HANA.xml
@@ -3,9 +3,8 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <general>
     <mode>
-      <final_restart_services config:type="boolean">
-      false
-    </final_restart_services>
+      <final_restart_services config:type="boolean">false</final_restart_services>
+      <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
     </mode>
     <ask-list config:type="list">
       <ask>
@@ -180,5 +179,6 @@ exit 0
   </software>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately
   </networking>
 </profile>

--- a/src/data/y2sap/HANA1.0.xml
+++ b/src/data/y2sap/HANA1.0.xml
@@ -3,9 +3,8 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <general>
     <mode>
-      <final_restart_services config:type="boolean">
-      false
-    </final_restart_services>
+      <final_restart_services config:type="boolean">false</final_restart_services>
+      <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
     </mode>
     <ask-list config:type="list">
       <ask>
@@ -190,5 +189,6 @@ check_masterpwd "$VAL"
   </software>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately
   </networking>
 </profile>

--- a/src/data/y2sap/STD.xml
+++ b/src/data/y2sap/STD.xml
@@ -3,9 +3,8 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 <general>
   <mode>
-    <final_restart_services config:type="boolean">
-      false
-    </final_restart_services>
+    <final_restart_services config:type="boolean">false</final_restart_services>
+    <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
   </mode>
   <ask-list config:type="list">
   
@@ -107,5 +106,6 @@ check_sid "$VAL"
 </software>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately>
   </networking>
 </profile>

--- a/src/data/y2sap/TREX.xml
+++ b/src/data/y2sap/TREX.xml
@@ -3,9 +3,8 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 <general>
   <mode>
-    <final_restart_services config:type="boolean">
-      false
-    </final_restart_services>
+    <final_restart_services config:type="boolean">false</final_restart_services>
+    <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
   </mode>
   <ask-list config:type="list">
   
@@ -144,5 +143,6 @@ check_instance_no "$VAL"
 </software>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately>
   </networking>
 </profile>

--- a/src/data/y2sap/Webdispatcher.xml
+++ b/src/data/y2sap/Webdispatcher.xml
@@ -3,9 +3,8 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 <general>
   <mode>
-    <final_restart_services config:type="boolean">
-      false
-    </final_restart_services>
+    <final_restart_services config:type="boolean">false</final_restart_services>
+    <activate_systemd_default_target config:type="boolean">false</activate_systemd_default_target>
   </mode>
   <ask-list config:type="list">
   
@@ -21,5 +20,6 @@
 </software>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
+    <start_immediately config:type="boolean">false</start_immediately>
   </networking>
 </profile>


### PR DESCRIPTION
## Problem

*Gnome session crashes during product xml will be applied.*

- *https://bugzilla.suse.com/show_bug.cgi?id=1184679*
- *https://openqa.suse.de/tests/14106450#step/wizard_hana_install/46*

## Solution

Apply proposed ayast parameters for all product xml:
- general.mode.activate_systemd_default_target = false
- networking.start_immediately =false
