### PR TITLE
bone-installation-wizard: hostname issue (B1 hostname differs from HANA)

### DIFF
--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Sep 10 11:13:32 UTC 2024 - Peter Varkoly <varkoly@suse.com>
+
+-  bone-installation-wizard: hostname issue (B1 hostname differs from HANA)
+  (bsc#1230165) Set the host name instead of the IP address and instead of the default values for all occurrences.
+  o Use FQHN for BCKP_HANA_SERVERS, HANA_DATABASE_SERVER, HANA_DATABASE_LOCATION and LOCAL_ADDRESS
+  o Add SL_** and WEBCLIENT parameters
+- 4.6.16 
+
+-------------------------------------------------------------------
 Tue Jun 11 16:59:03 UTC 2024 - Peter Varkoly <varkoly@suse.com>
 
 - openQA test fails in wizard_hana_install - Crash of Gnome session

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -19,7 +19,7 @@ Name:           sap-installation-wizard
 Summary:        Installation wizard for SAP applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.6.15
+Version:        4.6.16
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 Requires:       autoyast2
@@ -60,7 +60,7 @@ Authors:
 Summary:        Installation wizard for SAP Business One applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.6.15
+Version:        4.6.16
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 BuildRequires:  yast2

--- a/src/bin/b1_inst.sh
+++ b/src/bin/b1_inst.sh
@@ -62,7 +62,7 @@ TMPDIR=$(mktemp -t -d sap_install_XXXXX)
 chmod 755 $TMPDIR
 MEDIA_TARGET=$(dirname $SAPCD_INSTMASTER)
 
-HOSTNAME=$(hostname)
+HOSTNAME=$(hostname -f)
 IP_ADDR=$(gethostip -d $HOSTNAME)
 
 # YaST parameter take over
@@ -185,7 +185,6 @@ HANA_DATABASE_USER_ID=SYSTEM
 LANDSCAPE_INSTALL_ACTION=create
 LICENSE_SERVER_ACTION=register
 LICENSE_SERVER_NODE=standalone
-LOCAL_ADDRESS=${HOSTNAME}
 SELECTED_FEATURES=B1ServerToolsSLD,B1ServerToolsExtensionManager,B1ServerToolsLicense,B1ServerToolsJobService,B1ServerToolsMobileService,B1ServerToolsXApp,B1SLDAgent,B1WebClient,B1BackupService,B1ServerSHR,B1ServerCommonDB,B1ServerHelp_EN,B1ServerAddons,B1ServerOI,B1AnalyticsOlap,B1AnalyticsTomcatEntSearch,B1AnalyticsTomcatDashboard,B1AnalyticsTomcatReplication,B1AnalyticsTomcatConfiguration,B1AnalyticsTomcatPredictiveAnalysis,B1ServiceLayerComponent,B1ElectronicDocumentService,B1APIGatewayService
 SITE_USER_ID=B1SiteUser
 SLD_CERTIFICATE_ACTION=self
@@ -195,15 +194,22 @@ SLD_SERVER_PROTOCOL=https
 SLD_SERVER_TYPE=op
 INSTALLATION_FOLDER=/usr/sap/SAPBusinessOne
 INST_FOLDER_CORRECT_PERMISSIONS=true
+SL_LB_MEMBERS=127.0.0.1:50001,127.0.0.1:50002,127.0.0.1:50003,127.0.0.1:50004
+SL_LB_MEMBER_ONLY=false
+SL_LB_PORT=50000
+SL_THREAD_PER_SERVER=24
+WEBCLIENT_PORT=8443
 #### flexible part ###
-BCKP_HANA_SERVERS=<servers><server><system address="${IP_ADDR}"/><database instance="${A_SAPINSTNR}" port="3${A_SAPINSTNR}13" tenant-db="${A_SID}" user="SYSTEM" password="${A_MASTERPASS}"/></server></servers>
+BCKP_HANA_SERVERS=<servers><server><system address="${HOSTNAME}"/><database instance="${A_SAPINSTNR}" port="3${A_SAPINSTNR}13" tenant-db="${A_SID}" user="SYSTEM" password="${A_MASTERPASS}"/></server></servers>
 HANA_DATABASE_ADMIN_ID=${A_SID,,}adm
 HANA_DATABASE_TENANT_DB=${A_SID}
 HANA_DATABASE_INSTANCE=${A_SAPINSTNR}
 HANA_DATABASE_SERVER_PORT=3${A_SAPINSTNR}13
-HANA_DATABASE_SERVER=${IP_ADDR}
+HANA_DATABASE_SERVER=${HOSTNAME}
+HANA_DATABASE_LOCATION=${HOSTNAME}
 HANA_DATABASE_ADMIN_PASSWD=${A_MASTERPASS}
 HANA_DATABASE_USER_PASSWORD=${A_MASTERPASS}
+LOCAL_ADDRESS=${HOSTNAME}
 SITE_USER_PASSWORD=${A_MASTERPASS}
 EOF
 


### PR DESCRIPTION
bone-installation-wizard: hostname issue (B1 hostname differs from HANA)
  (bsc#1230165) Set the host name instead of the IP address and instead of the default values for all occurrences.
  o Use FQHN for BCKP_HANA_SERVERS, HANA_DATABASE_SERVER, HANA_DATABASE_LOCATION and LOCAL_ADDRESS
  o Add SL_** and WEBCLIENT parameters
