### PR TITLE
bone-installation-wizard: hostname issue (B1 hostname differs from HANA)

### DIFF
--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -4,6 +4,7 @@ Wed Sep 11 07:42:52 UTC 2024 - Peter Varkoly <varkoly@suse.com>
 - (bsc#1230165) Set the host name instead of the IP address and instead of the default values for all occurrences.
   o Use FQHN for BCKP_HANA_SERVERS, HANA_DATABASE_SERVER, HANA_DATABASE_LOCATION and LOCAL_ADDRESS
   o Add SL_** and WEBCLIENT parameters
+- Fix handling HANA XS routing mode.
 - 4.4.14
 
 -------------------------------------------------------------------

--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Sep 11 07:42:52 UTC 2024 - Peter Varkoly <varkoly@suse.com>
+
+- (bsc#1230165) Set the host name instead of the IP address and instead of the default values for all occurrences.
+  o Use FQHN for BCKP_HANA_SERVERS, HANA_DATABASE_SERVER, HANA_DATABASE_LOCATION and LOCAL_ADDRESS
+  o Add SL_** and WEBCLIENT parameters
+- 4.4.14
+
+-------------------------------------------------------------------
 Fri Jan 19 08:39:28 UTC 2024 - Peter Varkoly <varkoly@suse.com>
 
 - SAP Business One storage configuration failed for Fujitsu server (bsc#1218918)

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -19,7 +19,7 @@ Name:           sap-installation-wizard
 Summary:        Installation wizard for SAP applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.4.13
+Version:        4.4.14
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 Requires:       autoyast2

--- a/src/data/y2sap/HANA.xml
+++ b/src/data/y2sap/HANA.xml
@@ -120,56 +120,6 @@ exit $?
           <feedback config:type="boolean">true</feedback>
         </script>
       </ask>
-      <ask>
-        <title>SAP HANA System Parameters</title>
-        <dialog config:type="integer">10</dialog>
-        <element config:type="integer">50</element>
-        <width config:type="integer">70</width>
-        <height config:type="integer">20</height>
-        <help><![CDATA[
-             <p><b>SAP HANA XS routing mode.</b> This can be <i>hostname</i> or <i>ports</i>.
-	     </p>
-	     ]]></help>
-        <file>/var/run/sap-wizard/ay_q_xs_routing_mode</file>
-        <question>SAP HANA XS Routing Mode</question>
-        <stage>cont</stage>
-        <selection config:type="list"><default>hostname</defualt><default>ports^</defualt></selection>
-        <script>
-          <filename>xs_routing_mode.sh</filename>
-          <rerun_on_error config:type="boolean">true</rerun_on_error>
-          <environment config:type="boolean">true</environment>
-          <source><![CDATA[
-/usr/lib/YaST2/bin/sap_check_admin_pw.sh HANA
-exit $?
-]]></source>
-          <debug config:type="boolean">false</debug>
-          <feedback config:type="boolean">true</feedback>
-        </script>
-      </ask>
-      <ask>
-        <title>SAP HANA System Parameters</title>
-        <dialog config:type="integer">10</dialog>
-        <element config:type="integer">60</element>
-        <width config:type="integer">70</width>
-        <height config:type="integer">20</height>
-        <help><![CDATA[
-             <p><b>SAP HANA XS routing mode. This can be hostname or ports.
-	     </p>
-	     ]]></help>
-        <file>/var/run/sap-wizard/ay_q_xs_domain_name</file>
-        <question>SAP HANA XS Domain Name</question>
-        <stage>cont</stage>
-        <script>
-          <filename>xs_routing_mode.sh</filename>
-          <rerun_on_error config:type="boolean">true</rerun_on_error>
-          <environment config:type="boolean">true</environment>
-          <source><![CDATA[
-exit $?
-]]></source>
-          <debug config:type="boolean">false</debug>
-          <feedback config:type="boolean">true</feedback>
-        </script>
-      </ask>
     </ask-list>
   </general>
   <software>

--- a/src/lib/y2sap/media/check.rb
+++ b/src/lib/y2sap/media/check.rb
@@ -36,13 +36,13 @@ module Y2Sap
         IO.readlines(label_file).each do |line|
           fields = line.split(":")
           fields = line.split(" ") if filepath[-1] == "info.txt"
-          log.info("find_instmaster,search_labelfiles,fields: #{fields} size #{fields.size}")
+          log.info("find_instmaster,search_labelfiles,fields: #{label_file}: #{fields} size #{fields.size}")
           next if fields.size == 0
           instmaster = check_label(fields, label_file)
           return instmaster if !instmaster.nil?
         end
       end
-      return instmaster
+      return []
     end
 
     def check_label(fields, label_file)


### PR DESCRIPTION
## Problem
(bsc#1230165) Set the host name instead of the IP address and instead of the default values for all occurrences.

#Solution
o Use FQHN for BCKP_HANA_SERVERS, HANA_DATABASE_SERVER, HANA_DATABASE_LOCATION and LOCAL_ADDRESS
o Add SL_** and WEBCLIENT parameters

Wait only 1 minutes for starting B1 installer.

Fix handling HANA XS routing mode."