### PR TITLE
Fix bsc#1258485 SP4

### DIFF
--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Mar 13 13:40:26 UTC 2026 - Peter Varkoly <varkoly@suse.com>
+
+- SAP Business One 2602: failure to install (bsc#1258485)
+  o Add install parameter --lss_userid=800
+  o Replace deprecated parameter --lss_trust_unsigned_server by the new paramter --lss_trust_unsigned_components
+  o Do not remove passwd.xml file also if cleanup is not wanted
+- 4.4.17
+
+-------------------------------------------------------------------
 Mon Apr  7 18:32:15 UTC 2025 - Peter Varkoly <varkoly@suse.com>
 
 - bone-installation-wizard: missing landscape server address (bsc#1239627)

--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Apr  9 09:05:08 UTC 2026 - Peter Varkoly <varkoly@suse.com>
+
+- wizard_hana_install failed on "hdblcm --lss_trust_unsigned_components", it reports "Unknown option: lss_trust_unsigned_components"
+  (bsc#1261407)
+  Distinguish between a B1 installation and a standard HANA installation.
+- 4.4.18
+
+-------------------------------------------------------------------
 Fri Mar 13 13:40:26 UTC 2026 - Peter Varkoly <varkoly@suse.com>
 
 - SAP Business One 2602: failure to install (bsc#1258485)

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -19,7 +19,7 @@ Name:           sap-installation-wizard
 Summary:        Installation wizard for SAP applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.4.17
+Version:        4.4.18
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 Requires:       autoyast2

--- a/package/sap-installation-wizard.spec
+++ b/package/sap-installation-wizard.spec
@@ -19,7 +19,7 @@ Name:           sap-installation-wizard
 Summary:        Installation wizard for SAP applications
 License:        GPL-2.0+
 Group:          System/YaST
-Version:        4.4.16
+Version:        4.4.17
 Release:        0
 PreReq:         /bin/mkdir %fillup_prereq yast2
 Requires:       autoyast2

--- a/src/bin/hana_inst.sh
+++ b/src/bin/hana_inst.sh
@@ -191,6 +191,7 @@ cleanup() {
     rm -f  ${MEDIA_TARGET}/ay_*
     rm -rf ${SAPCD_INSTMASTER}
     rm -rf ${TMPDIR}
+    rm  ~/pwds.xml
   fi
 }
 
@@ -263,27 +264,28 @@ hana_lcm_workflow()
    if [ -z "${XS_ROUTING_MODE}" -o -z "${XS_DOMAIN_NAME}" -o "${XS_ROUTING_MODE}" == "ports" ]; then
        cat ~/pwds.xml | ./hdblcm --batch --action=install \
             --ignore=$TOIGNORE \
-            --lss_trust_unsigned_server \
+            --lss_trust_unsigned_components \
             --components=all \
             --sid=${SID} \
             --number=${SAPINSTNR} \
             --groupid=79 \
+            --lss_userid=800 \
             --read_password_from_stdin=xml \
             --xs_routing_mode=ports
    else
        cat ~/pwds.xml | ./hdblcm --batch --action=install \
             --ignore=$TOIGNORE \
-            --lss_trust_unsigned_server \
+            --lss_trust_unsigned_components \
             --components=all \
             --sid=${SID} \
             --number=${SAPINSTNR} \
             --groupid=79 \
+            --lss_userid=800 \
             --read_password_from_stdin=xml \
             --xs_routing_mode=${XS_ROUTING_MODE} \
 	    --xs_domain_name="${XS_DOMAIN_NAME}"
    fi
    rc=$?
-   rm  ~/pwds.xml
    return $rc
 }
 

--- a/src/bin/hana_inst.sh
+++ b/src/bin/hana_inst.sh
@@ -241,12 +241,16 @@ hana_lcm_workflow()
    hana_volumes
    hana_get_input
    hana_setenv_lcm
+   LSS_PARAM="--lss_trust_unsigned_server"
 
    # Detect if it is a B1 installation
    B1=$(find ${SAPCD_INSTMASTER}/ -maxdepth 1 -type f -exec grep FOR.B1 {} \;)
    if [ -n "$B1" -a ! -d ${SAPCD_INSTMASTER}/SAP_HANA_DATABASE ]; then
      # Move the component directories into the first level
      find ${SAPCD_INSTMASTER}/DATA_UNITS/  -type d -name "SAP_HANA_*" -exec mv {} ${SAPCD_INSTMASTER}/ \;
+   fi
+   if [ -n "$B1" ]; then
+     LSS_PARAM="--lss_trust_unsigned_components"
    fi
    # Find the installer
    HDBLCM=$(find ${SAPCD_INSTMASTER}/ -name hdblcm | grep -m 1 -P 'DATABASE|SERVER')
@@ -264,7 +268,7 @@ hana_lcm_workflow()
    if [ -z "${XS_ROUTING_MODE}" -o -z "${XS_DOMAIN_NAME}" -o "${XS_ROUTING_MODE}" == "ports" ]; then
        cat ~/pwds.xml | ./hdblcm --batch --action=install \
             --ignore=$TOIGNORE \
-            --lss_trust_unsigned_components \
+            ${LSS_PARAM} \
             --components=all \
             --sid=${SID} \
             --number=${SAPINSTNR} \
@@ -275,7 +279,7 @@ hana_lcm_workflow()
    else
        cat ~/pwds.xml | ./hdblcm --batch --action=install \
             --ignore=$TOIGNORE \
-            --lss_trust_unsigned_components \
+            ${LSS_PARAM} \
             --components=all \
             --sid=${SID} \
             --number=${SAPINSTNR} \


### PR DESCRIPTION
## Problem

*SAP Business One 2602: failure to install (bsc#1258485)*

- *https://bugzilla.suse.com/show_bug.cgi?id=1258485*

## Solution
  o Add install parameter --lss_userid=800
  o Replace deprecated parameter --lss_trust_unsigned_server by the new paramter --lss_trust_unsigned_components
  o Do not remove passwd.xml file also if cleanup is not wanted
