### PR TITLE
bsc#1261407

### DIFF
--- a/package/sap-installation-wizard.changes
+++ b/package/sap-installation-wizard.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Thu Apr  9 09:05:08 UTC 2026 - Peter Varkoly <varkoly@suse.com>
+Thu Apr 30 13:21:15 UTC 2026 - Peter Varkoly <varkoly@suse.com>
 
 - wizard_hana_install failed on "hdblcm --lss_trust_unsigned_components", it reports "Unknown option: lss_trust_unsigned_components"
   (bsc#1261407)

--- a/src/bin/hana_inst.sh
+++ b/src/bin/hana_inst.sh
@@ -249,9 +249,6 @@ hana_lcm_workflow()
      # Move the component directories into the first level
      find ${SAPCD_INSTMASTER}/DATA_UNITS/  -type d -name "SAP_HANA_*" -exec mv {} ${SAPCD_INSTMASTER}/ \;
    fi
-   if [ -n "$B1" ]; then
-     LSS_PARAM="--lss_trust_unsigned_components"
-   fi
    # Find the installer
    HDBLCM=$(find ${SAPCD_INSTMASTER}/ -name hdblcm | grep -m 1 -P 'DATABASE|SERVER')
    HDBLCMDIR=$(dirname "${HDBLCM}")
@@ -261,6 +258,14 @@ hana_lcm_workflow()
      return $rc
    fi
    cd "${HDBLCMDIR}"
+
+   if [ -n "$B1" ]; then
+     ver1=$( gawk '/fullversion:/ {print $2}' instruntime/manifest )
+     ver2="2.8.70"
+     if [ "$(printf '%s\n%s' "$ver1" "$ver2" | sort -V | head -n1)" = "$ver2" ]; then
+        LSS_PARAM="--lss_trust_unsigned_components"
+     fi
+   fi
    TOIGNORE="check_signature_file"
    if [ -e /root/hana-install-ignore ]; then
      TOIGNORE=$(cat /root/hana-install-ignore)


### PR DESCRIPTION
## Problem

*wizard_hana_install failed on "hdblcm --lss_trust_unsigned_components", it reports "Unknown option: lss_trust_unsigned_components"*

- https://bugzilla.suse.com/show_bug.cgi?id=1261407

The --lss_trust_unsigned_components is a parameter for HANA version inside B1 installer 2602 (SPS08 Rev87).
The issue here is that the new parameter is being passed on older HANA version, which does not have support for this option.

## Solution

Distinguish between a B1 installation and a standard HANA installation and analyse the version of HANA installer in case of B1. The new parameter name is valid only since version 2.8.70
